### PR TITLE
Added iTerm2 dark theme

### DIFF
--- a/gruvbox-dark.itermcolors
+++ b/gruvbox-dark.itermcolors
@@ -5,173 +5,173 @@
 	<key>Ansi 0 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.15686274510000001</real>
+		<real>0.15686275064945221</real>
 		<key>Green Component</key>
-		<real>0.15686274510000001</real>
+		<real>0.15686275064945221</real>
 		<key>Red Component</key>
-		<real>0.15686274510000001</real>
+		<real>0.15686275064945221</real>
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.20392156859999999</real>
+		<real>0.20392157137393951</real>
 		<key>Green Component</key>
-		<real>0.28627450980000002</real>
+		<real>0.28627452254295349</real>
 		<key>Red Component</key>
-		<real>0.98431372549999996</real>
+		<real>0.9843137264251709</real>
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.14901960784313725</real>
+		<real>0.14901961386203766</real>
 		<key>Green Component</key>
-		<real>0.73333333333333328</real>
+		<real>0.73333334922790527</real>
 		<key>Red Component</key>
-		<real>0.72156862745098038</real>
+		<real>0.72156864404678345</real>
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.18431372549019609</real>
+		<real>0.18431372940540314</real>
 		<key>Green Component</key>
-		<real>0.74117647058823533</real>
+		<real>0.74117648601531982</real>
 		<key>Red Component</key>
-		<real>0.98039215686274506</real>
+		<real>0.98039215803146362</real>
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.59607843137254901</real>
+		<real>0.59607845544815063</real>
 		<key>Green Component</key>
-		<real>0.6470588235294118</real>
+		<real>0.64705884456634521</real>
 		<key>Red Component</key>
-		<real>0.51372549019607838</real>
+		<real>0.51372551918029785</real>
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.60784313725490191</real>
+		<real>0.60784316062927246</real>
 		<key>Green Component</key>
-		<real>0.52549019607843139</real>
+		<real>0.52549022436141968</real>
 		<key>Red Component</key>
-		<real>0.82745098039215681</real>
+		<real>0.82745099067687988</real>
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.48627450980392156</real>
+		<real>0.48627451062202454</real>
 		<key>Green Component</key>
-		<real>0.75294117647058822</real>
+		<real>0.75294119119644165</real>
 		<key>Red Component</key>
-		<real>0.55686274509803924</real>
+		<real>0.55686277151107788</real>
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.69803921570000005</real>
+		<real>0.69803923369999998</real>
 		<key>Green Component</key>
-		<real>0.85882352939999995</real>
+		<real>0.85882353779999998</real>
 		<key>Red Component</key>
-		<real>0.92156862750000001</real>
+		<real>0.92156863209999995</real>
 	</dict>
 	<key>Ansi 2 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.14901960780000001</real>
+		<real>0.14901961386203766</real>
 		<key>Green Component</key>
-		<real>0.73333333329999995</real>
+		<real>0.73333334922790527</real>
 		<key>Red Component</key>
-		<real>0.72156862749999995</real>
+		<real>0.72156864404678345</real>
 	</dict>
 	<key>Ansi 3 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.1843137255</real>
+		<real>0.18431372940540314</real>
 		<key>Green Component</key>
-		<real>0.74117647060000003</real>
+		<real>0.74117648601531982</real>
 		<key>Red Component</key>
-		<real>0.98039215690000003</real>
+		<real>0.98039215803146362</real>
 	</dict>
 	<key>Ansi 4 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.59607843140000005</real>
+		<real>0.59607845544815063</real>
 		<key>Green Component</key>
-		<real>0.64705882349999999</real>
+		<real>0.64705884456634521</real>
 		<key>Red Component</key>
-		<real>0.51372549020000002</real>
+		<real>0.51372551918029785</real>
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.60784313729999995</real>
+		<real>0.60784316062927246</real>
 		<key>Green Component</key>
-		<real>0.52549019610000003</real>
+		<real>0.52549022436141968</real>
 		<key>Red Component</key>
-		<real>0.82745098039999998</real>
+		<real>0.82745099067687988</real>
 	</dict>
 	<key>Ansi 6 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.48627450979999998</real>
+		<real>0.48627451062202454</real>
 		<key>Green Component</key>
-		<real>0.75294117650000003</real>
+		<real>0.75294119119644165</real>
 		<key>Red Component</key>
-		<real>0.5568627451</real>
+		<real>0.55686277151107788</real>
 	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.69803921568627447</real>
+		<real>0.69803923368453979</real>
 		<key>Green Component</key>
-		<real>0.85882352941176465</real>
+		<real>0.85882353782653809</real>
 		<key>Red Component</key>
-		<real>0.92156862745098034</real>
+		<real>0.92156863212585449</real>
 	</dict>
 	<key>Ansi 8 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.15686274509803921</real>
+		<real>0.15686275064945221</real>
 		<key>Green Component</key>
-		<real>0.15686274509803921</real>
+		<real>0.15686275064945221</real>
 		<key>Red Component</key>
-		<real>0.15686274509803921</real>
+		<real>0.15686275064945221</real>
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.20392156862745098</real>
+		<real>0.20392157137393951</real>
 		<key>Green Component</key>
-		<real>0.28627450980392155</real>
+		<real>0.28627452254295349</real>
 		<key>Red Component</key>
-		<real>0.98431372549019602</real>
+		<real>0.9843137264251709</real>
 	</dict>
 	<key>Background Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.15686274510000001</real>
+		<real>0.15686275064945221</real>
 		<key>Green Component</key>
-		<real>0.15686274510000001</real>
+		<real>0.15686275064945221</real>
 		<key>Red Component</key>
-		<real>0.15686274510000001</real>
+		<real>0.15686275064945221</real>
 	</dict>
 	<key>Bold Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>1</real>
+		<real>0.75686274509999996</real>
 		<key>Green Component</key>
-		<real>1</real>
+		<real>0.95686274510000002</real>
 		<key>Red Component</key>
-		<real>1</real>
+		<real>0.99215686270000003</real>
 	</dict>
 	<key>Cursor Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.1843137255</real>
+		<real>0.18431372940540314</real>
 		<key>Green Component</key>
-		<real>0.74117647060000003</real>
+		<real>0.74117648601531982</real>
 		<key>Red Component</key>
-		<real>0.98039215690000003</real>
+		<real>0.98039215803146362</real>
 	</dict>
 	<key>Cursor Text Color</key>
 	<dict>
@@ -185,29 +185,29 @@
 	<key>Foreground Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.69803921570000005</real>
+		<real>0.75686274509999996</real>
 		<key>Green Component</key>
-		<real>0.85882352939999995</real>
+		<real>0.95686274510000002</real>
 		<key>Red Component</key>
-		<real>0.92156862750000001</real>
+		<real>0.99215686270000003</real>
 	</dict>
 	<key>Selected Text Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.69803921570000005</real>
+		<real>0.69803923368453979</real>
 		<key>Green Component</key>
-		<real>0.85882352939999995</real>
+		<real>0.85882353782653809</real>
 		<key>Red Component</key>
-		<real>0.92156862750000001</real>
+		<real>0.92156863212585449</real>
 	</dict>
 	<key>Selection Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.45490196078431372</real>
+		<real>0.45490196347236633</real>
 		<key>Green Component</key>
-		<real>0.51372549019607838</real>
+		<real>0.51372551918029785</real>
 		<key>Red Component</key>
-		<real>0.5725490196078431</real>
+		<real>0.57254904508590698</real>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Here are some pictures:
![screen shot 2013-11-16 at 7 35 40 pm](https://f.cloud.github.com/assets/2314074/1557614/a9bc383c-4f28-11e3-8d61-a28c6de96e99.png)
![screen shot 2013-11-16 at 7 36 07 pm](https://f.cloud.github.com/assets/2314074/1557615/ac8b5a52-4f28-11e3-8d23-aa547c0f86de.png)

I am using the fish shell, so don't take the name of the command as part of the theme (notice how `ls` is blue).
