### PR TITLE
Changed operator link from normal to structure

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -460,7 +460,7 @@ call s:HL('Label',       'red')
 " try, catch, throw
 call s:HL('Exception',   'red')
 " sizeof, "+", "*", etc.
-hi! link Operator Normal
+hi! link Operator Structure
 " Any other keyword
 call s:HL('Keyword',     'red')
 


### PR DESCRIPTION
This pull request changes the `link` for `Operator` syntax to use Structure instead of Normal. This matches what other color schemes use for this link, such as Jellybeans.