### PR TITLE
Change color of vertical/horizontal seperators between split windows

### DIFF
--- a/autoload/airline/themes/gruvbox.vim
+++ b/autoload/airline/themes/gruvbox.vim
@@ -47,7 +47,7 @@ function! airline#themes#gruvbox#refresh()
 	let g:airline#themes#gruvbox#palette.visual.airline_warning = g:airline#themes#gruvbox#palette.normal.airline_warning
 	let g:airline#themes#gruvbox#palette.visual_modified.airline_warning = g:airline#themes#gruvbox#palette.normal_modified.airline_warning
 
-	let s:IA = airline#themes#get_highlight2(['TabLine', 'fg'], ['CursorLine', 'bg'])
+	let s:IA = airline#themes#get_highlight2(['TabLine', 'bg'], ['StatusLine', 'fg'])
 	let g:airline#themes#gruvbox#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
 	let g:airline#themes#gruvbox#palette.inactive_modified = { 'airline_c': modified_group }
 

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -74,7 +74,7 @@ if !exists('g:gruvbox_color_column')
 endif
 
 if !exists('g:gruvbox_vert_split')
-	let g:gruvbox_vert_split='dark2'
+	let g:gruvbox_vert_split='dark4'
 endif
 
 if !exists('g:gruvbox_invert_signs')


### PR DESCRIPTION
This attempts to fix [#14](https://github.com/morhetz/gruvbox/issues/14) issued by @blueyed. Using color dark4 for vertical splits and also for horizontal statusbars of inactive windows gives (imho) a much better visual seperation of splits without conflicting with folds.