### PR TITLE
For terminals, turn off italics by default.

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -22,6 +22,10 @@ if !has('gui_running') && &t_Co != 256
 	finish
 endif
 
+if !has("gui_running")
+	let g:gruvbox_italic=0
+endif
+
 " }}}
 " Global Settings: {{{
 


### PR DESCRIPTION
Since this problem has cropped up so much... (#3, #4, #30, #41, #43, #44, #46).

Maybe a good default would be to turn off italics (for terminals only)?

Then, we could write a note in the readme with instructions for those who want them...