### PR TITLE
Added an option to use guisp as guifg for terminal users

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -41,8 +41,8 @@ endif
 if !exists('g:gruvbox_underline')
 	let g:gruvbox_underline=1
 endif
-if !exists('g:gruvbox_foreground_guisp')
-	let g:gruvbox_foreground_guisp=0
+if !exists('g:gruvbox_guisp_fallback') || index(['fg', 'bg'], g:gruvbox_guisp_fallback) == -1
+	let g:gruvbox_guisp_fallback='none'
 endif
 
 if !exists('g:gruvbox_italicize_comments')
@@ -232,7 +232,7 @@ function! s:HL(group, fg, ...)
 	let histring = 'hi ' . a:group . ' '
 
 	" if (Foreground override enabled) && (    We were passed a guisp value     )
-	if g:gruvbox_foreground_guisp != 0 && a:0 >= 3 && strlen(a:3) && a:3 != 'none'
+	if g:gruvbox_guisp_fallback == 'fg' && a:0 >= 3 && strlen(a:3) && a:3 != 'none'
 		let c = get(s:gb, a:3)
 		let histring .= 'guifg=#' . c[0] . ' ctermfg=' . c[1] . ' '
 	elseif strlen(a:fg)
@@ -248,7 +248,11 @@ function! s:HL(group, fg, ...)
 		endif
 	endif
 
-	if a:0 >= 1 && strlen(a:1)
+	" if (Background override enabled) && (    We were passed a guisp value     )
+	if g:gruvbox_guisp_fallback == 'bg' && a:0 >= 3 && strlen(a:3) && a:3 != 'none'
+		let c = get(s:gb, a:3)
+		let histring .= 'guibg=#' . c[0] . ' ctermbg=' . c[1] . ' '
+	elseif a:0 >= 1 && strlen(a:1)
 		if a:1 == 'bg'
 			let histring .= 'guibg=bg ctermbg=bg '
 		elseif a:fg == 'fg'

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -41,6 +41,9 @@ endif
 if !exists('g:gruvbox_underline')
 	let g:gruvbox_underline=1
 endif
+if !exists('g:gruvbox_foreground_guisp')
+	let g:gruvbox_foreground_guisp=0
+endif
 
 if !exists('g:gruvbox_italicize_comments')
 	let g:gruvbox_italicize_comments=1
@@ -228,7 +231,11 @@ function! s:HL(group, fg, ...)
 
 	let histring = 'hi ' . a:group . ' '
 
-	if strlen(a:fg)
+	" if (Foreground override enabled) && (    We were passed a guisp value     )
+	if g:gruvbox_foreground_guisp != 0 && a:0 >= 3 && strlen(a:3) && a:3 != 'none'
+		let c = get(s:gb, a:3)
+		let histring .= 'guifg=#' . c[0] . ' ctermfg=' . c[1] . ' '
+	elseif strlen(a:fg)
 		if a:fg == 'fg'
 			let histring .= 'guifg=fg ctermfg=fg '
 		elseif a:fg == 'bg'


### PR DESCRIPTION
People in the console can't see guisp colors, and therefore can't tell the difference between different kinds of spelling errors.

This commit adds a workaround; a `g:gruvbox_guisp_as_guifg` variable which allows the guisp color to override the guifg color, so the entire word changes color instead of just the underline.

![before](https://cloud.githubusercontent.com/assets/382798/6313912/46b61b1a-ba28-11e4-9dd8-0c0c1bfc964c.png)
![after](https://cloud.githubusercontent.com/assets/382798/6313909/40da53d2-ba28-11e4-9622-ee899267a0c9.png)


