### PR TITLE
color for markdown code spans and blocks

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1008,6 +1008,13 @@ call s:HL('scalaInstanceDeclaration', 'light1')
 call s:HL('scalaInterpolation', 'aqua')
 
 " }}}
+" Markdown: {{{
+
+call s:HL('markdownCodeDelimiter', 'green')
+call s:HL('markdownCode', 'green')
+call s:HL('markdownCodeBlock', 'green')
+
+" }}}
 
 " Functions -------------------------------------------------------------------
 " Search Highlighting Cursor {{{


### PR DESCRIPTION
Makes it nicer to take notes in Vim by adding highlighting for code blocks and spans

[Before](http://imgur.com/pIW21AE,ccIBnNO#0)
[After](http://imgur.com/pIW21AE,ccIBnNO#1)