### PR TITLE
add minimal coloring for gitcommit highlighting

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -649,6 +649,12 @@ else
 endif
 
 " }}}
+" gitcommit highlighting "{{{
+
+call s:HL('gitcommitSelectedFile', 'green')
+call s:HL('gitcommitDiscardedFile', 'red')
+
+" }}}
 " Signify: {{{
 
 if g:gruvbox_invert_signs == 0


### PR DESCRIPTION
Adding colors for fugitive's `Gstatus` command

Before: (can't tell which files will be committed)
![screen shot 2015-03-02 at 2 33 50 am](https://cloud.githubusercontent.com/assets/489562/6436928/23f994b8-c085-11e4-9682-efe309a07f48.png)

After: (ahhh...much better)
![screen shot 2015-03-02 at 2 34 21 am](https://cloud.githubusercontent.com/assets/489562/6436931/286fd656-c085-11e4-826f-2442e17e5c16.png)
