### PR TITLE
Fix the 256 palette script failed login issue

### DIFF
--- a/gruvbox_256palette.sh
+++ b/gruvbox_256palette.sh
@@ -76,10 +76,8 @@ if [ "${TERM%%-*}" = "screen" ]; then
 		printf "\033P\033]4;66;rgb:42/7b/58\007\033\\"
 		printf "\033P\033]4;130;rgb:af/3a/03\007\033\\"
 	fi
-else
-	if [ "$TERM" = "linux" ] || [ "$TERM" = "vt100" ] || [ "$TERM" = "vt220" ]; then
-		exit 1
-	fi
+
+elif [ "$TERM" != "linux" ] && [ "$TERM" != "vt100" ] && [ "$TERM" != "vt220" ]; then
 
 	printf "\033]4;236;rgb:32/30/2f\033\\"
 	printf "\033]4;234;rgb:1d/20/21\033\\"


### PR DESCRIPTION
Shouldn't `exit` from a shellscript that's meant to be sourced automatically on login shells.

Fixes #48