### PR TITLE
Adds colors for italic, bold, and code in markdown

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1014,6 +1014,13 @@ call s:HL('scalaInstanceDeclaration', 'light1')
 call s:HL('scalaInterpolation', 'aqua')
 
 " }}}
+" Markdown: {{{
+call s:HL('markdownItalic', 'yellow')
+call s:HL('markdownBold', 'red')
+call s:HL('markdownCode', 'blue')
+call s:HL('markdownCodeBlock', 'blue')
+call s:HL('markdownCodeDelimiter', 'blue')
+" }}}
 
 " Functions -------------------------------------------------------------------
 " Search Highlighting Cursor {{{


### PR DESCRIPTION
I like @xdl's suggestion in #51, except I don't want code and headers to be the same color. (Some fonts, including Fira Mono which I use, don't have bold defined so that distinction is lost in vim.) Also added bold and italics.

I found that if you don't have Tim Pope's [vim-markdown](https://github.com/tpope/vim-markdown) plugin installed, the bold delimiters (should be red) pick up the italic color (yellow). There are also [several](https://github.com/tpope/vim-markdown/issues/37) [discussions](https://github.com/tpope/vim-markdown/pull/16) about inline underscores in his repo—it seems like the best thing to do is just escape them, so I left as-is.