### PR TITLE
indentLine defaults only applied if not supplied by user

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -607,8 +607,12 @@ endif
 " }}}
 " IndentLine: {{{
 
-let g:indentLine_color_term = s:gb.dark2[1]
-let g:indentLine_color_gui = '#' . s:gb.dark2[0]
+if !exists('g:indentLine_color_term')
+	let g:indentLine_color_term = s:gb.dark2[1]
+endif
+if !exists('g:indentLine_color_gui')
+	let g:indentLine_color_gui = '#' . s:gb.dark2[0]
+endif
 
 " }}}
 " Rainbow Parentheses: {{{


### PR DESCRIPTION
Currently the gruvbox colors for indentLine apply even if I have set my own colors in .vimrc. This PR fixes that, and only applies the colors if the user has not supplied them.