### PR TITLE
Add italic for Todo highlight group

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -474,7 +474,7 @@ if g:gruvbox_italicize_comments == 0
 else
 	call s:HL('Comment', 'medium', 'none', 'italic')
 endif
-call s:HL('Todo', 'fg', 'bg', 'bold')
+call s:HL('Todo', 'fg', 'bg', 'bold,italic')
 call s:HL('Error', 'bg', 'red', 'bold')
 
 " Generic statement


### PR DESCRIPTION
Just a minor adjustment. The todo group is not italicized even though italicized is enabled on comments.

This is what it looks like without the patch and italicized comments is enabled:
![initial](https://cloud.githubusercontent.com/assets/722817/9658802/b209c8a0-527e-11e5-8434-c2a0317d0c63.png)

After the patch this is what it looks like when italicized is enabled:
![italicized](https://cloud.githubusercontent.com/assets/722817/9658807/c289bba4-527e-11e5-9fce-ae4661d08ebe.png)

And when it is disabled:
![non_italic](https://cloud.githubusercontent.com/assets/722817/9658812/cdf930c8-527e-11e5-89dc-1fa04c24fc6f.png)
