### PR TITLE
Added tty support

### DIFF
--- a/gruvbox_256palette.sh
+++ b/gruvbox_256palette.sh
@@ -118,7 +118,7 @@ elif [ "$TERM" != "linux" ] && [ "$TERM" != "vt100" ] && [ "$TERM" != "vt220" ];
 
 elif [ "$TERM" != "linux" ]
 
-  printf "\e]P0000000" # Background
+  printf "\e]P0282828" # Background
 
   printf "\e]P1ff0000" # Red
   printf "\e]P200ff00" # Green

--- a/gruvbox_256palette.sh
+++ b/gruvbox_256palette.sh
@@ -116,7 +116,7 @@ elif [ "$TERM" != "linux" ] && [ "$TERM" != "vt100" ] && [ "$TERM" != "vt220" ];
   printf "\033]4;66;rgb:42/7b/58\033\\"
   printf "\033]4;130;rgb:af/3a/03\033\\"
 
-elif [ "$TERM" != "linux" ]; then
+elif [ "$TERM" = "linux" ]; then
 
   printf "\e]P0282828" # Background
 
@@ -129,14 +129,17 @@ elif [ "$TERM" != "linux" ]; then
 
   printf "\e]P7aaaaaa" # Foreground
 
-  printf "\e]P8666666" # Bold Background
+  # Bold colors that can be used as aditionnal foreground colors
+  printf "\e]P8666666" # Bold Black (grey, for comments)
 
   printf "\e]P9ff7777" # Bold Red
   printf "\e]PA77ff77" # Bold Green
-  printf "\e]PBffff55" # Bold Yellow
+  printf "\e]PBffff55" # Bold Yellow (could be orange)
   printf "\e]PC7777ff" # Bold Blue
   printf "\e]PDff55ff" # Bold Magenta
   printf "\e]PE55ffff" # Bold Cyan
 
   printf "\e]PFffffff" # Bold Foreground
+
+  clear # Actualisates the background
 fi

--- a/gruvbox_256palette.sh
+++ b/gruvbox_256palette.sh
@@ -115,4 +115,28 @@ elif [ "$TERM" != "linux" ] && [ "$TERM" != "vt100" ] && [ "$TERM" != "vt220" ];
   printf "\033]4;96;rgb:8f/3f/71\033\\"
   printf "\033]4;66;rgb:42/7b/58\033\\"
   printf "\033]4;130;rgb:af/3a/03\033\\"
+
+elif [ "$TERM" != "linux" ]
+
+  printf "\e]P0000000" # Background
+
+  printf "\e]P1ff0000" # Red
+  printf "\e]P200ff00" # Green
+  printf "\e]P3bbbb00" # Yellow
+  printf "\e]P40000ff" # Blue
+  printf "\e]P5aa00bb" # Magenta
+  printf "\e]P600bbbb" # Cyan
+
+  printf "\e]P7aaaaaa" # Foreground
+
+  printf "\e]P8666666" # Bold Background
+
+  printf "\e]P9ff7777" # Bold Red
+  printf "\e]PA77ff77" # Bold Green
+  printf "\e]PBffff55" # Bold Yellow
+  printf "\e]PC7777ff" # Bold Blue
+  printf "\e]PDff55ff" # Bold Magenta
+  printf "\e]PE55ffff" # Bold Cyan
+
+  printf "\e]PFffffff" # Bold Foreground
 fi

--- a/gruvbox_256palette.sh
+++ b/gruvbox_256palette.sh
@@ -116,7 +116,7 @@ elif [ "$TERM" != "linux" ] && [ "$TERM" != "vt100" ] && [ "$TERM" != "vt220" ];
   printf "\033]4;66;rgb:42/7b/58\033\\"
   printf "\033]4;130;rgb:af/3a/03\033\\"
 
-elif [ "$TERM" != "linux" ]
+elif [ "$TERM" != "linux" ]; then
 
   printf "\e]P0282828" # Background
 

--- a/gruvbox_256palette.sh
+++ b/gruvbox_256palette.sh
@@ -120,26 +120,26 @@ elif [ "$TERM" = "linux" ]; then
 
   printf "\e]P0282828" # Background
 
-  printf "\e]P1ff0000" # Red
-  printf "\e]P200ff00" # Green
-  printf "\e]P3bbbb00" # Yellow
-  printf "\e]P40000ff" # Blue
-  printf "\e]P5aa00bb" # Magenta
-  printf "\e]P600bbbb" # Cyan
+  printf "\e]P1fb4934" # Red
+  printf "\e]P2b8bb26" # Green
+  printf "\e]P3fabd2f" # Yellow
+  printf "\e]P483a490" # Blue
+  printf "\e]P5d3869b" # Magenta
+  printf "\e]P68ec07c" # Cyan
 
-  printf "\e]P7aaaaaa" # Foreground
+  printf "\e]P7d5c4a1" # Foreground
 
   # Bold colors that can be used as aditionnal foreground colors
   printf "\e]P8666666" # Bold Black (grey, for comments)
 
-  printf "\e]P9ff7777" # Bold Red
-  printf "\e]PA77ff77" # Bold Green
-  printf "\e]PBffff55" # Bold Yellow (could be orange)
-  printf "\e]PC7777ff" # Bold Blue
-  printf "\e]PDff55ff" # Bold Magenta
-  printf "\e]PE55ffff" # Bold Cyan
+  printf "\e]P99d0006" # Bold Red
+  printf "\e]PA79740e" # Bold Green
+  printf "\e]PBb57614" # Bold Yellow (could be orange)
+  printf "\e]PC076678" # Bold Blue
+  printf "\e]PD9f3f81" # Bold Magenta
+  printf "\e]PE427b58" # Bold Cyan
 
-  printf "\e]PFffffff" # Bold Foreground
+  printf "\e]PFf9f5d7" # Bold Foreground
 
   clear # Actualisates the background
 fi


### PR DESCRIPTION
I found this nice trick from [here](http://askubuntu.com/questions/147462/how-can-i-change-the-tty-colors) and [here](https://github.com/joepvd/tty-solarized).

And I use this a lot without root and without problem on Ubuntu, ArchLinux and Open-SUSE.