### PR TITLE
Add python conditionals, loops and dotted names

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -927,6 +927,9 @@ hi! link pythonOperator GruvboxRed
 hi! link pythonExceptions GruvboxPurple
 hi! link pythonBoolean GruvboxPurple
 hi! link pythonDot GruvboxFg3
+hi! link pythonConditional GruvboxRed
+hi! link pythonRepeat GruvboxRed
+hi! link pythonDottedName GruvboxGreenBold
 
 " }}}
 " CSS: {{{


### PR DESCRIPTION
`if`, `for`, `while` and decorator invocations are currently not highlighted.

The colors are definitely up for discussion, I just wanted to bring this up and prefered to do it with a PR instead of just an issue.
