### PR TITLE
Add terminal_colors for neovim

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -132,6 +132,43 @@ let s:gb.faded_aqua     = ['#427b58', 66]      " 66-123-88
 let s:gb.faded_orange   = ['#af3a03', 130]     " 175-58-3
 
 " }}}
+" Setup Terminal Colors For Neovim: {{{
+
+if has('nvim')
+  " dark0 + gray
+  let g:terminal_color_0 = "#282828"
+  let g:terminal_color_8 = "#928374"
+
+  " neurtral_red + bright_red
+  let g:terminal_color_1 = "#cc241d"
+  let g:terminal_color_9 = "#fb4934"
+
+  " neutral_green + bright_green
+  let g:terminal_color_2 = "#98971a"
+  let g:terminal_color_10 = "#b8bb26"
+
+  " neutral_yellow + bright_yellow
+  let g:terminal_color_3 = "#d79921"
+  let g:terminal_color_11 = "#fabd2f"
+
+  " neutral_blue + bright_blue
+  let g:terminal_color_4 = "#458588"
+  let g:terminal_color_12 = "#83a598"
+
+  " neutral_purple + bright_purple
+  let g:terminal_color_5 = "#b16286"
+  let g:terminal_color_13 = "#d3869b"
+
+  " neutral_aqua + faded_aqua
+  let g:terminal_color_6 = "#689d6a"
+  let g:terminal_color_14 = "#8ec07c"
+
+  " light4 + light1
+  let g:terminal_color_7 = "#a89984"
+  let g:terminal_color_15 = "#ebdbb2"
+endif
+
+" }}}
 " Setup Emphasis: {{{
 
 let s:bold = 'bold,'


### PR DESCRIPTION
Neovim has support for embedded terminals. However, the colors do not inherit from the parent shell settings, and end up looking funky. This commit adds 16 color support for Neovim's terminal.

See: https://github.com/neovim/neovim/issues/2897#issuecomment-115464516