### PR TITLE
No more messy Signature variable assignment

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -747,12 +747,8 @@ hi! link SyntasticWarningSign GruvboxYellowSign
 
 " }}}
 " Signature: {{{
-
+hi! link SignatureMarkText   GruvboxBlueSign
 hi! link SignatureMarkerText GruvboxPurpleSign
-hi! link SignatureMarkText GruvboxBlueSign
-
-let g:SignatureMarkerTextHL='"SignatureMarkerText"'
-let g:SignatureMarkTextHL='"SignatureMarkText"'
 
 " }}}
 " ShowMarks: {{{


### PR DESCRIPTION
A little background about Signature's dynamically choosing the highlight groups for the signs. The idea is that by assigning `g:SignatureMarkTextHL` to a function reference we can decide what highlight group to use for the sign at the time of placing it. This is described [here](https://github.com/kshenoy/vim-signature/issues/42#issuecomment-52402420) in more detail.

I happened to notice that gruvbox supports Signature (thanks for that) and in order to do so assigns the `g:SignatureMarkTextHL` variable. This caused the aforementioned feature to break. One way to fix that would be to check if dynamic highlighting is set by the user but requires GruvBox to be aware of Signature's logic which IMHO is a very bad idea. 

Thus, to make life easier, I created 4 highlight groups - SignatureMarkText, SignatureMarkerText, SignatureMarkLine and SignatureMarkerLine - that can be set by themes instead of messing about with variable assignments.