### PR TITLE
Highlight elixir module declarations

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1122,6 +1122,8 @@ hi! link elixirDocString Comment
 hi! link elixirStringDelimiter GruvboxGreen
 hi! link elixirInterpolationDelimiter GruvboxAqua
 
+hi! link elixirModuleDeclaration GruvboxYellow
+
 " }}}
 " Scala: {{{
 


### PR DESCRIPTION
The following commit in vim-elixir caused modules in module declarations to no longer be
highlighted yellow.

https://github.com/elixir-lang/vim-elixir/commit/babcd09769a2d45fbd93aed326c959d1e1a35523

This adds a `elixirModuleDeclaration` highlight to make the
modules yellow again.

Here's the current colors:
<img width="203" alt="screen shot 2016-08-18 at 2 28 06 pm" src="https://cloud.githubusercontent.com/assets/342554/17785867/7b405696-6550-11e6-984e-83ca6c34b631.png">

Here's the colors in this PR:
<img width="217" alt="screen shot 2016-08-18 at 2 27 47 pm" src="https://cloud.githubusercontent.com/assets/342554/17785888/8b70fd7c-6550-11e6-9338-71a6bd2da885.png">
