### PR TITLE
Add support for PureScript and better support for Haskell

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1195,9 +1195,9 @@ hi! link haskellStatement GruvboxOrange
 hi! link haskellConditional GruvboxRed
 hi! link haskellKeyword GruvboxRed
 hi! link haskellLet GruvboxRed
+hi! link haskellWhere GruvboxRed
 
 hi! link haskellDefault GruvboxAqua
-hi! link haskellWhere GruvboxAqua
 hi! link haskellBottom GruvboxAqua
 hi! link haskellBlockKeywords GruvboxAqua
 hi! link haskellImportKeywords GruvboxAqua
@@ -1215,17 +1215,21 @@ hi! link haskellChar GruvboxGreen
 " }}}
 " Purescript {{{
 hi! link purescriptFunction GruvboxFg1
+hi! link purescriptTypeVar GruvboxFg1
+
 hi! link purescriptDelimiter GruvboxFg3
 hi! link purescriptOperator GruvboxFg3
+hi! link purescriptOperatorTypeSig GruvboxFg3
+hi! link purescriptForall GruvboxFg3
+
 hi! link purescriptImportKeyword GruvboxAqua
-hi! link purescriptWhere GruvboxAqua
-hi! link purescriptModuleName GruvboxYellow
-hi! link purescriptConstructor GruvboxYellow
+hi! link purescriptWhere GruvboxRed
 hi! link purescriptModuleKeyword GruvboxAqua
 hi! link purescriptAsKeyword GruvboxAqua
 hi! link purescriptStructure GruvboxAqua
-hi! link purescriptForall GruvboxFg3
-hi! link purescriptTypeVar GruvboxFg1
+
+hi! link purescriptModuleName GruvboxYellow
+hi! link purescriptConstructor GruvboxYellow
 
 
 " }}}

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1220,6 +1220,7 @@ hi! link purescriptOperator GruvboxFg3
 hi! link purescriptImportKeyword GruvboxAqua
 hi! link purescriptWhere GruvboxAqua
 hi! link purescriptModuleName GruvboxYellow
+hi! link purescriptConstructor GruvboxYellow
 hi! link purescriptModuleKeyword GruvboxAqua
 hi! link purescriptAsKeyword GruvboxAqua
 hi! link purescriptStructure GruvboxAqua

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1194,8 +1194,8 @@ hi! link haskellStatement GruvboxOrange
 
 hi! link haskellConditional GruvboxRed
 hi! link haskellKeyword GruvboxRed
+hi! link haskellLet GruvboxRed
 
-hi! link haskellLet GruvboxAqua
 hi! link haskellDefault GruvboxAqua
 hi! link haskellWhere GruvboxAqua
 hi! link haskellBottom GruvboxAqua

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1181,20 +1181,19 @@ hi! link markdownIdDeclaration markdownLinkText
 " }}}
 " Haskell: {{{
 
-" hi! link haskellType GruvboxYellow
-" hi! link haskellOperators GruvboxOrange
-" hi! link haskellConditional GruvboxAqua
-" hi! link haskellLet GruvboxOrange
-"
-hi! link haskellType GruvboxFg1
+hi! link haskellType GruvboxYellow
+
 hi! link haskellIdentifier GruvboxFg1
-hi! link haskellSeparator GruvboxFg1
-hi! link haskellDelimiter GruvboxFg4
-hi! link haskellOperators GruvboxBlue
-"
-hi! link haskellBacktick GruvboxOrange
+
+hi! link haskellSeparator GruvboxFg3
+hi! link haskellDelimiter GruvboxFg3
+hi! link haskellOperators GruvboxFg3
+hi! link haskellBacktick GruvboxFg3
+
 hi! link haskellStatement GruvboxOrange
-hi! link haskellConditional GruvboxOrange
+
+hi! link haskellConditional GruvboxRed
+hi! link haskellKeyword GruvboxRed
 
 hi! link haskellLet GruvboxAqua
 hi! link haskellDefault GruvboxAqua
@@ -1203,6 +1202,7 @@ hi! link haskellBottom GruvboxAqua
 hi! link haskellBlockKeywords GruvboxAqua
 hi! link haskellImportKeywords GruvboxAqua
 hi! link haskellDeclKeyword GruvboxAqua
+hi! link haskellDecl GruvboxAqua
 hi! link haskellDeriving GruvboxAqua
 hi! link haskellAssocType GruvboxAqua
 

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1213,6 +1213,21 @@ hi! link haskellString GruvboxGreen
 hi! link haskellChar GruvboxGreen
 
 " }}}
+" Purescript {{{
+hi! link purescriptFunction GruvboxFg1
+hi! link purescriptDelimiter GruvboxFg3
+hi! link purescriptOperator GruvboxFg3
+hi! link purescriptImportKeyword GruvboxAqua
+hi! link purescriptWhere GruvboxAqua
+hi! link purescriptModuleName GruvboxYellow
+hi! link purescriptModuleKeyword GruvboxAqua
+hi! link purescriptAsKeyword GruvboxAqua
+hi! link purescriptStructure GruvboxAqua
+hi! link purescriptForall GruvboxFg3
+hi! link purescriptTypeVar GruvboxFg1
+
+
+" }}}
 " Json: {{{
 
 hi! link jsonKeyword GruvboxGreen

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1219,7 +1219,7 @@ hi! link purescriptTypeVar GruvboxFg1
 
 hi! link purescriptDelimiter GruvboxFg3
 hi! link purescriptOperator GruvboxFg3
-hi! link purescriptOperatorTypeSig GruvboxFg3
+hi! link purescriptFunctionDecl GruvboxFg3
 hi! link purescriptForall GruvboxFg3
 
 hi! link purescriptImportKeyword GruvboxAqua


### PR DESCRIPTION
The default syntax highlighting provided by purescript-vim and haskell-vim didn't work very well with this colorscheme, so I've updated gruvbox.vim to better support the languages.

I tried to retain the aesthetic of the project the best I could, but feel free to critique my color selections.

### Screenshots

*Haskell*

![image](https://cloud.githubusercontent.com/assets/2536121/18229062/868f5e84-72ac-11e6-966e-f577c89b2a43.png)

![image](https://cloud.githubusercontent.com/assets/2536121/18229034/7a5ee202-72ab-11e6-92ed-4a2130e58dfe.png)

*PureScript*

![image](https://cloud.githubusercontent.com/assets/2536121/18229047/cdbbdfea-72ab-11e6-88d7-a26b44413af7.png)


![image](https://cloud.githubusercontent.com/assets/2536121/18229042/b1921c4e-72ab-11e6-9814-d4010c52f056.png)

