### PR TITLE
Add ability to set transparent background (none)

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -173,6 +173,8 @@ if s:is_dark
     let s:bg0  = s:gb.dark0_soft
   elseif g:gruvbox_contrast_dark == 'hard'
     let s:bg0  = s:gb.dark0_hard
+  elseif g:gruvbox_contrast_dark == 'none'
+    let s:bg0  = [0,0]
   endif
 
   let s:bg1  = s:gb.dark1
@@ -203,6 +205,8 @@ else
     let s:bg0  = s:gb.light0_soft
   elseif g:gruvbox_contrast_light == 'hard'
     let s:bg0  = s:gb.light0_hard
+  elseif g:gruvbox_contrast_light == 'none'
+    let s:bg0  = [0,0]
   endif
 
   let s:bg1  = s:gb.light1


### PR DESCRIPTION
Adding `highlight Normal ctermbg=None`, like in #96 suggested, did not create transparent background for me. Thus I figured out a way to add this behavior with an additional value `none` for `g:gruvbox_contrast_dark` and `g:gruvbox_contrast_light`.