### PR TITLE
Color operator keywords

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -558,8 +558,8 @@ hi! link Repeat GruvboxRed
 hi! link Label GruvboxRed
 " try, catch, throw
 hi! link Exception GruvboxRed
-" sizeof, "+", "*", etc.
-hi! link Operator Normal
+" sizeof, and, or, etc.
+hi! link Operator GruvboxRed
 " Any other keyword
 hi! link Keyword GruvboxRed
 


### PR DESCRIPTION
`Operator` seems to contain keyword operators, rather than punctuator operators, so should be colored like other keywords.

Currently color operators do not appear correctly in Ada and Lua, and I'm sure more, and this was probably patched as a special case for any languages where this doesn't happen. Words like `and` and `or` appear like identifiers in such languages currently.