### PR TITLE
JS globals different fg color

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1156,8 +1156,8 @@ hi! link jsClassKeyword GruvboxAqua
 hi! link jsExtendsKeyword GruvboxAqua
 hi! link jsExportDefault GruvboxAqua
 hi! link jsTemplateBraces GruvboxAqua
-hi! link jsGlobalNodeObjects GruvboxFg1
-hi! link jsGlobalObjects GruvboxFg1
+hi! link jsGlobalNodeObjects GruvboxBlue
+hi! link jsGlobalObjects GruvboxBlue
 hi! link jsFunction GruvboxAqua
 hi! link jsFuncParens GruvboxFg3
 hi! link jsParens GruvboxFg3


### PR DESCRIPTION
Highlight the use of node/js global constants so they don't look like user-defined variables

Here the `module` keyword is being highlighted, before it had the same fg color as the rest of the code
<img width="404" alt="screen shot 2017-11-18 at 12 00 31 pm" src="https://user-images.githubusercontent.com/3936773/32983304-20199a0a-cc58-11e7-9e4e-5235023bc336.png">
