### PR TITLE
Use augroup for autocmds

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -688,8 +688,11 @@ hi! link EasyMotionShade Comment
 " }}}
 " Sneak: {{{
 
-autocmd ColorScheme gruvbox hi! link Sneak Search
-autocmd ColorScheme gruvbox hi! link SneakLabel Search
+augroup gruvbox-sneak
+  autocmd!
+  autocmd ColorScheme gruvbox hi! link Sneak Search
+  autocmd ColorScheme gruvbox hi! link SneakLabel Search
+augroup END
 
 " }}}
 " Indent Guides: {{{


### PR DESCRIPTION
`:autocmd` appends a entry every time, so autocmd entries accumulate when we reload the colorscheme(`:colorscheme gruvbox`).

![2018-01-21_01h46_03](https://user-images.githubusercontent.com/20474/35185802-0c97f43c-fe4d-11e7-8f49-77d6fdcdddd0.png)

This PR adds `augroup` to avoid this.
