### PR TITLE
Added color for QuickFixLine (matches Error)

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -509,6 +509,8 @@ hi! link VisualNOS Visual
 call s:HL('Search',    s:yellow, s:bg0, s:inverse)
 call s:HL('IncSearch', s:hls_cursor, s:bg0, s:inverse)
 
+call s:HL('QuickFixLine', s:bg0, s:red, s:bold) 
+
 call s:HL('Underlined', s:blue, s:none, s:underline)
 
 call s:HL('StatusLine',   s:bg2, s:fg1, s:inverse)


### PR DESCRIPTION
There was no color for the QuickFixLine so my terminal was rendering it as a hideous unreadable cyan. This fix made gives it the same color scheme as Error.