### PR TITLE
Link pangloss jsFuncCall to GruvboxBlue.

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1159,6 +1159,7 @@ hi! link jsTemplateBraces GruvboxAqua
 hi! link jsGlobalNodeObjects GruvboxFg1
 hi! link jsGlobalObjects GruvboxFg1
 hi! link jsFunction GruvboxAqua
+hi! link jsFuncCall GruvboxBlue
 hi! link jsFuncParens GruvboxFg3
 hi! link jsParens GruvboxFg3
 hi! link jsNull GruvboxPurple


### PR DESCRIPTION
Use GruvboxAqua for jsFuncCall highlight group. It's much more readable with it.

Before:
![before](https://i.imgur.com/uj3csYL.png)

After:
![after](https://i.imgur.com/s5Ow6t0.png)