### PR TITLE
change part of html

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -908,12 +908,12 @@ hi! link diffLine GruvboxBlue
 hi! link htmlTag GruvboxBlue
 hi! link htmlEndTag GruvboxBlue
 
-hi! link htmlTagName GruvboxAquaBold
-hi! link htmlArg GruvboxAqua
+hi! link htmlTagName GruvboxRed
+hi! link htmlArg GruvboxYellow
 
-hi! link htmlScriptTag GruvboxPurple
+hi! link htmlScriptTag GruvboxBlue
 hi! link htmlTagN GruvboxFg1
-hi! link htmlSpecialTagName GruvboxAquaBold
+hi! link htmlSpecialTagName GruvboxPurple
 
 call s:HL('htmlLink', s:fg4, s:none, s:underline)
 


### PR DESCRIPTION
Hello, I like this theme too much and don't want to change other topics. But I think gruvbox's html syntax highlight is too monotonous, especially the color of the tag, so I changed the color of the html part with the color of the onedark and gruvbox to make it clear. If my pr doesn't pass, please make some changes to the html syntax highlighting, I am looking forward to it.