### PR TITLE
Mutually exclusive vars checked independently

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -69,12 +69,8 @@ if exists('g:gruvbox_contrast')
   echo 'g:gruvbox_contrast is deprecated; use g:gruvbox_contrast_light and g:gruvbox_contrast_dark instead'
 endif
 
-if !exists('g:gruvbox_contrast_dark')
+if !exists('g:gruvbox_contrast_dark') && !exists('g:gruvbox_contrast_light')
   let g:gruvbox_contrast_dark='medium'
-endif
-
-if !exists('g:gruvbox_contrast_light')
-  let g:gruvbox_contrast_light='medium'
 endif
 
 let s:is_dark=(&background == 'dark')


### PR DESCRIPTION
g:gruvbox_contrast_dark and g:gruvbox_contrast_light were evaluated one after another. In order to correctly set the contrast to dark, one would have to define both contrast_dark as true and contrast_light as false; otherwise:

`if !exists('g:gruvbox_contrast_light')` evaluates to True, and a user who actually has "g:gruvbox_contrast_dark" = 1 set will still end up with medium contrast.