### PR TITLE
Add highlighting configuration for Tex

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -641,7 +641,7 @@ if version >= 700
   " Popup menu: normal item
   call s:HL('Pmenu', s:fg1, s:bg2)
   " Popup menu: selected item
-  call s:HL('PmenuSel', s:bg2, s:blue, s:bold)
+  call s:HL('PmenuSel', s:bg2, s:bg3, s:bold)
   " Popup menu: scrollbar
   call s:HL('PmenuSbar', s:none, s:bg2)
   " Popup menu: scrollbar thumb

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1412,6 +1412,10 @@ hi! link texOnlyMath cleared
 hi! link texSuperscript texMath
 hi! link texSubscript texMath
 
+" vimtex 2.0
+hi! link texCmd GruvboxAqua
+hi! link texArg GruvboxBlue
+
 " }}}
 
 

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -3,7 +3,7 @@
 " Description: Retro groove color scheme for Vim
 " Author: morhetz <morhetz@gmail.com>
 " Source: https://github.com/morhetz/gruvbox
-" Last Modified: 07 Jun 2019
+" Last Modified: 04 Jun 2020
 " -----------------------------------------------------------------------------
 
 " Supporting code -------------------------------------------------------------
@@ -1397,7 +1397,17 @@ hi! link jsonString GruvboxFg1
 " }}}
 " Tex: {{{
 
+hi! link texStatement GruvboxAqua
+hi! link texCmdName GruvboxAqua
+hi! link texNewCmd GruvboxAqua
+hi! link texDefCmd GruvboxAqua
+hi! link texDefName GruvboxAqua
+hi! link texNewEnv GruvboxAqua
+hi! link texRefZone GruvboxBlue
+hi! link texBeginEndName GruvboxBlue
+
 hi! link texMathSymbol GruvboxAqua
+hi! link texMathDelim GruvboxAqua
 hi! link texOnlyMath cleared
 hi! link texSuperscript texMath
 hi! link texSubscript texMath

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -87,7 +87,7 @@ let s:gb = {}
 
 " fill it with absolute colors
 let s:gb.dark0_hard  = ['#1d2021', 234]     " 29-32-33
-let s:gb.dark0       = ['#282828', 235]     " 40-40-40
+let s:gb.dark0       = ['#262626', 235]     " 38-38-38
 let s:gb.dark0_soft  = ['#32302f', 236]     " 50-48-47
 let s:gb.dark1       = ['#3c3836', 237]     " 60-56-54
 let s:gb.dark2       = ['#504945', 239]     " 80-73-69

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -3,7 +3,7 @@
 " Description: Retro groove color scheme for Vim
 " Author: morhetz <morhetz@gmail.com>
 " Source: https://github.com/morhetz/gruvbox
-" Last Modified: 12 Aug 2017
+" Last Modified: 07 Jun 2019
 " -----------------------------------------------------------------------------
 
 " Supporting code -------------------------------------------------------------
@@ -683,7 +683,6 @@ endif
 " Plugin specific -------------------------------------------------------------
 " EasyMotion: {{{
 
-hi! link EasyMotionTarget Search
 hi! link EasyMotionShade Comment
 
 " }}}
@@ -1398,6 +1397,11 @@ hi! link jsonKeyword GruvboxGreen
 hi! link jsonQuote GruvboxGreen
 hi! link jsonBraces GruvboxFg1
 hi! link jsonString GruvboxFg1
+
+" }}}
+" Tex: {{{
+
+hi! link texMathSymbol GruvboxAqua
 
 " }}}
 

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1402,6 +1402,9 @@ hi! link jsonString GruvboxFg1
 " Tex: {{{
 
 hi! link texMathSymbol GruvboxAqua
+hi! link texOnlyMath cleared
+hi! link texSuperscript texMath
+hi! link texSubscript texMath
 
 " }}}
 

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -664,18 +664,14 @@ call s:HL('DiffText',   s:yellow, s:bg0, s:inverse)
 " Spelling: {{{
 
 if has("spell")
-  " Not capitalised word, or compile warnings
-  if g:gruvbox_improved_warnings == 0
-    call s:HL('SpellCap',   s:none, s:none, s:undercurl, s:red)
-  else
-    call s:HL('SpellCap',   s:green, s:none, s:bold . s:italic)
-  endif
+  " Not capitalised word
+  call s:HL('SpellCap', s:red, s:none, s:italic . s:undercurl, s:red)
   " Not recognized word
-  call s:HL('SpellBad',   s:none, s:none, s:undercurl, s:blue)
+  call s:HL('SpellBad', s:blue, s:none, s:italic . s:undercurl, s:blue)
   " Wrong spelling for selected region
-  call s:HL('SpellLocal', s:none, s:none, s:undercurl, s:aqua)
+  call s:HL('SpellLocal', s:aqua, s:none, s:italic . s:undercurl, s:aqua)
   " Rare word
-  call s:HL('SpellRare',  s:none, s:none, s:undercurl, s:purple)
+  call s:HL('SpellRare', s:purple, s:none, s:italic . s:undercurl, s:purple)
 endif
 
 " }}}


### PR DESCRIPTION
Thanks for the terrific color scheme!

I found the original color for math symbol is too close to their surroundings, which make the equations are hard to read as follows.
![image](https://user-images.githubusercontent.com/15342165/59099994-50aa2a00-8957-11e9-912d-5d1fcdd80c8b.png)
After changing the color for math symbol, the equations seem better as follows.
![image](https://user-images.githubusercontent.com/15342165/59100139-bbf3fc00-8957-11e9-863a-20023fdcbf19.png)
In addition, the original EasyMotionTarget is bold red, but it is linked to `search` currently, which makes it hard to see clearly as follows.
![image](https://user-images.githubusercontent.com/15342165/59100377-7552d180-8958-11e9-87f8-afed79ce2394.png)
If somebody wants to use `search` for EasyMotionTarget, it still can be set in one's own configuration file. I think we should keep the original setting in EasyMotion by default, and this is actually easier to see as follows.
![image](https://user-images.githubusercontent.com/15342165/59100519-ded2e000-8958-11e9-8f90-6d9017fe042a.png)

I would also prefer to define more elaborate colors for `Tex`, and you are welcome to give any suggestions or ideas.