### PR TITLE
Fix keywords for vim-javascript

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1164,6 +1164,7 @@ hi! link jsParens GruvboxFg3
 hi! link jsNull GruvboxPurple
 hi! link jsUndefined GruvboxPurple
 hi! link jsClassDefinition GruvboxYellow
+hi! link jsOperatorKeyword GruvboxRed
 
 " }}}
 " TypeScript: {{{


### PR DESCRIPTION
When using https://github.com/pangloss/vim-javascript, keywords are not colored. This is fixed by simply adding a highlight command to `jsOperatorKeyword`.