### PR TITLE
Add support for coc.nvim

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -454,6 +454,7 @@ call s:HL('GruvboxYellowSign', s:yellow, s:sign_column, s:invert_signs)
 call s:HL('GruvboxBlueSign', s:blue, s:sign_column, s:invert_signs)
 call s:HL('GruvboxPurpleSign', s:purple, s:sign_column, s:invert_signs)
 call s:HL('GruvboxAquaSign', s:aqua, s:sign_column, s:invert_signs)
+call s:HL('GruvboxOrangeSign', s:orange, s:sign_column, s:invert_signs)
 
 " }}}
 
@@ -887,6 +888,30 @@ hi! link NERDTreeToggleOff GruvboxRed
 
 call s:HL('multiple_cursors_cursor', s:none, s:none, s:inverse)
 call s:HL('multiple_cursors_visual', s:none, s:bg2)
+
+" }}}
+" coc.nvim: {{{
+
+hi! link CocErrorSign GruvboxRedSign
+hi! link CocWarningSign GruvboxOrangeSign
+hi! link CocInfoSign GruvboxYellowSign
+hi! link CocHintSign GruvboxBlueSign
+hi! link CocErrorFloat GruvboxRed
+hi! link CocWarningFloat GruvboxOrange
+hi! link CocInfoFloat GruvboxYellow
+hi! link CocHintFloat GruvboxBlue
+hi! link CocDiagnosticsError GruvboxRed
+hi! link CocDiagnosticsWarning GruvboxOrange
+hi! link CocDiagnosticsInfo GruvboxYellow
+hi! link CocDiagnosticsHint GruvboxBlue
+
+hi! link CocSelectedText GruvboxRed
+hi! link CocCodeLens GruvboxGray
+
+call s:HL('CocErrorHighlight', s:none, s:none, s:undercurl, s:red)
+call s:HL('CocWarningHighlight', s:none, s:none, s:undercurl, s:orange)
+call s:HL('CocInfoHighlight', s:none, s:none, s:undercurl, s:yellow)
+call s:HL('CocHintHighlight', s:none, s:none, s:undercurl, s:blue)
 
 " }}}
 


### PR DESCRIPTION
This PR adds support for the vim-plugin `coc.nvim` (a plugin similar to `ALE`).

A few changes might be up for debate.

The default gui color for `CocSelectedText` and `CocCodeLens` are a custom red and blue-ish grey set by `coc.nvim` itself. I have mapped those to `GruvboxRed` and `GruvboxGray`.

A lot of other colors of the form `CocListForegroundBackground' are also defined by `coc.nvim`. However, they seem to link to default colors so I think there is no need to redefine this.

By default, `coc.nvim` displays info in yellow and hints in blue. IMO, it is more logical the other way around. However, since this is a personal opinion, I did use the `coc.nvim`-defaults.