### PR TITLE
Add support for vim-lsp

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -761,6 +761,21 @@ hi! link gitcommitSelectedFile GruvboxGreen
 hi! link gitcommitDiscardedFile GruvboxRed
 
 " }}}
+" vim-lsp: "{{{
+
+hi! link LspErrorHighlight GruvboxRed
+hi! link LspWarningHighlight GruvboxYellow
+hi! link LspInformationHighlight GruvboxBlue
+hi! link LspHintHighlight GruvboxBlue
+
+hi! link LspErrorText GruvboxRedSign
+hi! link LspWarningText GruvboxYellowSign
+hi! link LspInformationText GruvboxBlueSign
+hi! link LspHintText GruvboxBlueSign
+
+call s:HL('lspReference', s:none, s:none, s:inverse . s:italic, s:none)
+
+" }}}
 " Signify: {{{
 
 hi! link SignifySignAdd GruvboxGreenSign


### PR DESCRIPTION
This PR adds support for [vim-lsp](https://github.com/prabirshrestha/vim-lsp) plugin. 

I have tried to mimic the color logic(errors, warnings, ...) of other plugins.

References are not "on" by default they are highlighted only if user sets:
```vim-script
let g:lsp_highlight_references_enabled = 1
```