### PR TITLE
Link Operator to foreground but not background

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -588,7 +588,7 @@ hi! link Label GruvboxRed
 " try, catch, throw
 hi! link Exception GruvboxRed
 " sizeof, "+", "*", etc.
-hi! link Operator Normal
+hi! link Operator GruvboxFg1
 " Any other keyword
 hi! link Keyword GruvboxRed
 


### PR DESCRIPTION
The Normal group sets both foreground and background.
When 'cursorline' is enabled and the current line contains an Operator,
the background defined for Normal "wins" and overrides the background
defined for CursorLine.

This change links Operator to GruvboxFg1 instead
which uses the same foreground but does not override the background.