### PR TITLE
Customize color groupings for rust syntax

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1263,6 +1263,13 @@ hi! link goDeclType GruvboxBlue
 hi! link goBuiltins GruvboxOrange
 
 " }}}
+" Rust: {{{
+
+hi! link rustFuncCall GruvboxBlue
+hi! link rustCommentLineDoc GruvboxFg3
+hi! link rustLifetime GruvboxAqua
+
+" }}}
 " Lua: {{{
 
 hi! link luaIn GruvboxRed


### PR DESCRIPTION
This pr fixes some issues with rust syntax:

- Doc comments now a stage lighter then normal comments instead of orange
- Function calls now blue to distinguish between it and a string literal
- Rust's lifetime syntax change to aqua to make then stand out from the operators in a definition

Before:

<img width="356" alt="before" src="https://user-images.githubusercontent.com/2746374/81516370-a0326c00-9305-11ea-902b-6b42456739d0.png">

After:

<img width="361" alt="after" src="https://user-images.githubusercontent.com/2746374/81516374-a3c5f300-9305-11ea-9733-1f54278090ef.png">

Fixes #333 