### PR TITLE
Add support for Nvim LSP client

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -920,6 +920,10 @@ hi! link LspDiagnosticsErrorSign GruvboxRedSign
 hi! link LspDiagnosticsWarningSign GruvboxOrangeSign
 hi! link LspDiagnosticsInformationSign GruvboxYellowSign
 hi! link LspDiagnosticsHintSign GruvboxBlueSign
+hi! link LspDiagnosticsErrorFloating GruvboxRed
+hi! link LspDiagnosticsWarningFloating GruvboxOrange
+hi! link LspDiagnosticsInformationFloating GruvboxYellow
+hi! link LspDiagnosticsHintFloating GruvboxBlue
 hi! link LspDiagnosticsError GruvboxRed
 hi! link LspDiagnosticsWarning GruvboxOrange
 hi! link LspDiagnosticsInformation GruvboxYellow

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -918,12 +918,12 @@ call s:HL('CocHintHighlight', s:none, s:none, s:undercurl, s:blue)
 
 hi! link LspDiagnosticsErrorSign GruvboxRedSign
 hi! link LspDiagnosticsWarningSign GruvboxOrangeSign
-hi! link LspDiagnosticInformationSign GruvboxYellowSign
-hi! link LspDiagnosticHintSign GruvboxBlueSign
+hi! link LspDiagnosticsInformationSign GruvboxYellowSign
+hi! link LspDiagnosticsHintSign GruvboxBlueSign
 hi! link LspDiagnosticsError GruvboxRed
 hi! link LspDiagnosticsWarning GruvboxOrange
-hi! link LspDiagnosticInformation GruvboxYellow
-hi! link LspDiagnosticHint GruvboxBlue
+hi! link LspDiagnosticsInformation GruvboxYellow
+hi! link LspDiagnosticsHint GruvboxBlue
 
 " }}}
 

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -914,6 +914,18 @@ call s:HL('CocInfoHighlight', s:none, s:none, s:undercurl, s:yellow)
 call s:HL('CocHintHighlight', s:none, s:none, s:undercurl, s:blue)
 
 " }}}
+" Nvim LSP client {{{
+
+hi! link LspDiagnosticsErrorSign GruvboxRedSign
+hi! link LspDiagnosticsWarningSign GruvboxOrangeSign
+hi! link LspDiagnosticInformationSign GruvboxYellowSign
+hi! link LspDiagnosticHintSign GruvboxBlueSign
+hi! link LspDiagnosticsError GruvboxRed
+hi! link LspDiagnosticsWarning GruvboxOrange
+hi! link LspDiagnosticInformation GruvboxYellow
+hi! link LspDiagnosticHint GruvboxBlue
+
+" }}}
 
 " Filetype specific -----------------------------------------------------------
 " Diff: {{{


### PR DESCRIPTION
This PR adds highlighting for the build-in Nvim LSP client.

Things that may still need to be added in order to complete the support for that client are the addition of the following highlight groups:

```
                                                           *hl-LspReferenceText*
LspReferenceText          used for highlighting "text" references
                                                           *hl-LspReferenceRead*
LspReferenceRead          used for highlighting "read" references
                                                          *hl-LspReferenceWrite*
LspReferenceWrite         used for highlighting "write" references
```
