### PR TITLE
color: modified background color for SyntasticError and SyntasticWarning

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -770,8 +770,8 @@ hi! link SignifySignDelete GruvboxRedSign
 " }}}
 " Syntastic: {{{
 
-call s:HL('SyntasticError', s:none, s:none, s:undercurl, s:red)
-call s:HL('SyntasticWarning', s:none, s:none, s:undercurl, s:yellow)
+call s:HL('SyntasticError', s:vim_fg, s:red, s:undercurl, s:red)
+call s:HL('SyntasticWarning', s:vim_fg, s:orange, s:undercurl, s:yellow)
 
 hi! link SyntasticErrorSign GruvboxRedSign
 hi! link SyntasticWarningSign GruvboxYellowSign


### PR DESCRIPTION
So I have been using this change on all of my machines for a while, and still not see a pull request to patch it.

I wounder whether it is worth to be patched or not, perhaps people more like the current setting.
But I do found reported issue of it #222, so I decide to create this pull request anyway.

The current setting will only put underscore on the error or warning session, I think it might be better to have a highlight background color for that.