### PR TITLE
Add ability to customize the color of the vertical split line

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -333,6 +333,11 @@ if exists('g:gruvbox_vert_split')
   let s:vert_split = get(s:gb, g:gruvbox_vert_split)
 endif
 
+let s:vert_split_line = s:bg3
+if exists('g:gruvbox_vert_split_line')
+  let s:vert_split_line = get(s:gb, g:gruvbox_vert_split_line)
+endif
+
 let s:invert_signs = ''
 if exists('g:gruvbox_invert_signs')
   if g:gruvbox_invert_signs == 1
@@ -516,7 +521,7 @@ call s:HL('StatusLine',   s:bg2, s:fg1, s:inverse)
 call s:HL('StatusLineNC', s:bg1, s:fg4, s:inverse)
 
 " The column separating vertically split windows
-call s:HL('VertSplit', s:bg3, s:vert_split)
+call s:HL('VertSplit', s:vert_split_line, s:vert_split)
 
 " Current match in wildmenu completion
 call s:HL('WildMenu', s:blue, s:bg2, s:bold)


### PR DESCRIPTION
Hello, first of, great job on this color scheme, it's my new favorite 🥇 

This PR adds the ability to customize the color of the vertical split **line**.

I know we can customize many colors of this scheme using global variables. We even have a variable to customize the background of the vertical split line, but we can't customize the foreground.

See the screenshots below:

1. Not customizing the split line at all just for the sake of comparing them (default behaviour for the split line):

![pr1 - default](https://user-images.githubusercontent.com/2293178/94979009-64838300-04ee-11eb-9cd3-572a2350c45e.png)

2. I've customized the vert line using the existing variable `let g:gruvbox_vert_split='bg1'` so we can see the difference.

![pr2](https://user-images.githubusercontent.com/2293178/94979010-65b4b000-04ee-11eb-97b7-e16757585be8.png)

3. I've customized the new variable `g:gruvbox_vert_split_line` making the line a bit darker.

![pr3](https://user-images.githubusercontent.com/2293178/94979011-66e5dd00-04ee-11eb-9303-9a09a2d98abd.png)

4. I've customized the new variable to remove the line altogether by matching with the background. (🌟, my favorite)

![pr4](https://user-images.githubusercontent.com/2293178/94979012-677e7380-04ee-11eb-9f74-70ccdfd13d33.png)


This is something that I was using myself and I decided to share because it could be useful for more people. I'll be glad to update the wiki if this PR gets merged.

Thank you 🙌 