### PR TITLE
Operator is linked to Normal.

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -588,7 +588,7 @@ hi! link Label GruvboxRed
 " try, catch, throw
 hi! link Exception GruvboxRed
 " sizeof, "+", "*", etc.
-hi! link Operator Normal
+hi! link Operator GruvboxFg1
 " Any other keyword
 hi! link Keyword GruvboxRed
 


### PR DESCRIPTION
[Operator](https://github.com/morhetz/gruvbox/blob/master/colors/gruvbox.vim#L591) is linked to [Normal](https://github.com/morhetz/gruvbox/blob/master/colors/gruvbox.vim#L465) but [Normal](https://github.com/morhetz/gruvbox/blob/master/colors/gruvbox.vim#L465) have background color. This is causing problems with the following plugins; [vim-javascript](https://github.com/pangloss/vim-javascript) and [coc-tsserver](https://github.com/neoclide/coc-tsserver).

<img width="1271" alt="Operator" src="https://user-images.githubusercontent.com/3394043/109360171-c7a7f480-7897-11eb-8ad8-1087cb7423fd.png">
