### PR TITLE
Documentation to set background color

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,26 @@ Screenshots
 Refer [Gallery][] for more syntax-specific screenshots.
 
    [Gallery]: https://github.com/morhetz/gruvbox/wiki/Gallery
+   
+   
 
 ### Dark mode
 
 ![Screenshot Dark](http://i.imgur.com/GkIl8Fn.png)
+   
+   to enable this you need to set background as dark
+   ```
+   set bg=dark
+   ```
 
 ### Light mode
 
 ![Screenshot Light](http://i.imgur.com/X75niEa.png)
+
+   light theme is enabled by default, to enable this manually you need to set background as light
+   ```
+   set bg=dark
+   ```
 
 ### Airline theme
 


### PR DESCRIPTION
Documentation clearly does not mention how to apply specific theme, you've to google it and get it from one of issue filed.
Probably this was confusing for new vim learner like me. This theme set light color by default, and no way to understand how to set back to dark

another theme documentation mentions it like
```
set background="dark"
```

which is not valid here