### PR TITLE
Alternate foreground and background color for visualizing indent guides

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -702,10 +702,10 @@ endif
 if g:indent_guides_auto_colors == 0
   if g:gruvbox_invert_indent_guides == 0
     call s:HL('IndentGuidesOdd', s:vim_bg, s:bg2)
-    call s:HL('IndentGuidesEven', s:vim_bg, s:bg1)
+    call s:HL('IndentGuidesEven', s:bg1, s:vim_bg)
   else
     call s:HL('IndentGuidesOdd', s:vim_bg, s:bg2, s:inverse)
-    call s:HL('IndentGuidesEven', s:vim_bg, s:bg3, s:inverse)
+    call s:HL('IndentGuidesEven', s:bg3, s:vim_bg, s:inverse)
   endif
 endif
 


### PR DESCRIPTION
I really like your color scheme and basically use it as my color scheme anywhere I can - thank you for sharing back your marvelous work!

The one thing I like less about it, are the indent guides (at least when using the vim-indent-guides plugin). I typically change the second alternating color to the background, which makes the indent guides more calm on the eyes.

So what do you think about it? I'm looking forward to your feedback!