### PR TITLE
Add support for Perl (vim-perl/vim-perl)

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1048,6 +1048,11 @@ hi! link pythonRepeat GruvboxRed
 hi! link pythonDottedName GruvboxGreenBold
 
 " }}}
+" Perl: {{{
+
+hi! link perlOperator GruvboxRed
+
+" }}}
 " CSS: {{{
 
 hi! link cssBraces GruvboxBlue


### PR DESCRIPTION
so that perl operators like `undef`, `defined`, `eq`, etc. are colored red.