### PR TITLE
Fix statusline breakage with NeoVim 0.11

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -512,8 +512,14 @@ call s:HL('IncSearch', s:hls_cursor, s:bg0, s:inverse)
 
 call s:HL('Underlined', s:blue, s:none, s:underline)
 
-call s:HL('StatusLine',   s:bg2, s:fg1, s:inverse)
-call s:HL('StatusLineNC', s:bg1, s:fg4, s:inverse)
+" See issue #465
+if has('nvim-0.11')
+  call s:HL('StatusLine',   s:bg2, s:fg1)
+  call s:HL('StatusLineNC', s:bg1, s:fg4)
+else
+  call s:HL('StatusLine',   s:bg2, s:fg1, s:inverse)
+  call s:HL('StatusLineNC', s:bg1, s:fg4, s:inverse)
+endif
 
 " The column separating vertically split windows
 call s:HL('VertSplit', s:bg3, s:vert_split)


### PR DESCRIPTION
Fixes #465.

For reference, see https://neovim.io/doc/user/news-0.11.html.

The fix here is similar https://github.com/ellisonleao/gruvbox.nvim/commit/c74e6e523c4827b67af2cb02b636e22dc35fdf70, except here the arguments are not swapped; that produced a different result for me entirely, whereas this restores the 0.10.4 appearance.