### PR TITLE
Use only background colors in diff mode

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -649,16 +649,25 @@ if version >= 700
 endif
 
 " }}}
-" Diffs: {{{
+" Diff mode: {{{
 
-call s:HL('DiffDelete', s:red, s:bg0, s:inverse)
-call s:HL('DiffAdd',    s:green, s:bg0, s:inverse)
+" Using colors and inverse
+"call s:HL('DiffDelete', s:red, s:bg0, s:inverse)
+"call s:HL('DiffAdd',    s:green, s:bg0, s:inverse)
 "call s:HL('DiffChange', s:bg0, s:blue)
 "call s:HL('DiffText',   s:bg0, s:yellow)
 
-" Alternative setting
+" Using colors and inverse, alternative setting
+call s:HL('DiffDelete', s:red, s:bg0, s:inverse)
+call s:HL('DiffAdd',    s:green, s:bg0, s:inverse)
 call s:HL('DiffChange', s:aqua, s:bg0, s:inverse)
 call s:HL('DiffText',   s:yellow, s:bg0, s:inverse)
+
+" Using background colors only
+"call s:HL('DiffDelete', s:bg2, s:bg2)
+"call s:HL('DiffAdd',    s:none, s:bg0)
+"call s:HL('DiffChange', s:none, s:bg0)
+"call s:HL('DiffText',   s:none, s:bg1)
 
 " }}}
 " Spelling: {{{


### PR DESCRIPTION
# Summary

Add a second alternative to the diff-mode highlighting to only use background colors to show diffs. This creates less-intense colors and shows the file syntax (Vimscript, C, LISP, etc.) and the diffs at the same time. See the included screenshots. Let me know if you would like more details; my repo has design notes, but I've kept them out of the PR.

(Also change "Diffs:" section title to "Diff mode:" to distinguish it from the "Diff:" filetype-specific colors.)

# Screenshots

## Using `bg2` for deleted lines

<img width="970" height="507" alt="Screenshot with light background and bg2" src="https://github.com/user-attachments/assets/6137bb6e-303b-435e-ac7c-e91c4c76c3d0" />
<img width="970" height="507" alt="Screenshot with dark background and bg2" src="https://github.com/user-attachments/assets/1f09f9b6-0e27-4cad-860f-dd62dcfe22eb" />

## Using `bg3` for deleted lines

<img width="970" height="507" alt="Screenshot with light background and bg3" src="https://github.com/user-attachments/assets/c427c325-9190-4848-ac3c-86461ebc0f0a" />
<img width="970" height="507" alt="Screenshot with dark background and bg3" src="https://github.com/user-attachments/assets/dc6b0378-c980-4ee6-855f-842b59ed3445" />